### PR TITLE
configure.ac: Do not use pkg-config.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,8 @@ AC_PROG_LIBTOOL
 AM_PROG_CC_C_O
 AM_PROG_AS
 
-PKG_CHECK_MODULES([CHECK], [check >= 0.9.4])
+AC_CHECK_HEADER([check.h], [], AC_MSG_ERROR([unable to find check]))
+AM_PATH_CHECK([0.9.4])
 
 LT_INIT()
 


### PR DESCRIPTION
Instead, use AC_CHECK_HEADER and the check-specific macro
AM_PATH_CHECK.
