### PR TITLE
return the right error messages

### DIFF
--- a/tests/check_watchman.c
+++ b/tests/check_watchman.c
@@ -164,6 +164,7 @@ START_TEST(test_watchman_watch)
     /* we expect to get nothing back from this one */
     struct watchman_query_result *result =
         watchman_do_query(conn, test_dir, NULL, since, &error);
+    ck_assert_msg(result != NULL, error.message);
     ck_assert_int_eq(0, result->nr);
     char *clock = strdup(result->clock);
     watchman_free_query_result(result);


### PR DESCRIPTION
1. When we encounter an error blocking on watchman, exit
watchman_read_with_timeout at that time (so that the user sees the
correct error.

2. When select() in block_in_read() times out, block_on_read returns
0.  When this happens, let the user know that we've timed out (rather
than returning a weird error about EAGAIN).