### PR TITLE
configure.ac: Comment indicating why you might get a AM_PATH_CHECK() …

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,9 @@ AM_PROG_CC_C_O
 AM_PROG_AS
 
 AC_CHECK_HEADER([check.h], [], AC_MSG_ERROR([unable to find check]))
+# NOTE: If you get an error about check.h, install "check" and get an
+# error about AM_PATH_CHECK() you need to re-run autogen.sh, since the
+# AM_PATH_CHECK comes with the "check" package.
 AM_PATH_CHECK([0.9.4])
 
 LT_INIT()


### PR DESCRIPTION
…syntax error

If you run the configure script and get an error about check.h, then
re-run configure after installing it you'll get:

    ./configure: line 11641: syntax error near unexpected token `0.9.4'
    ./configure: line 11641: `AM_PATH_CHECK(0.9.4)'

That's because the AM_PATH_CHECK macro comes with check itself, so we
need to re-run autogen.sh. Add a comment about this in case anyone else
runs into the same issue.