### PR TITLE
Add trace/warning/error routines, report BSER parse errors

### DIFF
--- a/bser.h
+++ b/bser.h
@@ -68,7 +68,9 @@ bser_t* bser_object_value_at(bser_t* bser, size_t index);
 /* Retrieve error message if the node is an error node */
 const char* bser_error_message(bser_t* bser);
 
-/* Convert a BSER representation into a json (jansson) representation */
-json_t* bser2json(bser_t* bser);
+/* Convert a BSER representation into a json (jansson) representation.
+ * Upon an error, NULL is returned and 'err' is filled in with the error
+ * message. */
+json_t* bser2json(bser_t* bser, json_error_t* err);
 
 #endif /* ndef LIBWATCHMAN_BSER_H */

--- a/bser_parse.c
+++ b/bser_parse.c
@@ -147,9 +147,8 @@ bser_parse_from_file(FILE* fp, bser_t* fill)
     uint8_t magic[2];
     int64_t size;
 
-    if (fread(magic, 1, 2, fp) != 2 ||
-        magic[0] != 0 ||
-        magic[1] != 1) {
+    int status = fread(magic, 1, 2, fp);
+    if (status != 2 || magic[0] != 0 || magic[1] != 1) {
         return new_error("Could not read bser magic values", fill);
     } else if (integer_from_file(fp, &size)) {
         return new_error("Could not read bser length", fill);

--- a/proto.h
+++ b/proto.h
@@ -122,7 +122,12 @@ proto_dumps(proto_t p, int flags)
     json_t* json = p.u.json;
     char* result;
     if (p.type == PROTO_BSER) {
-        json = bser2json(p.u.bser);
+        json_error_t err;
+        json = bser2json(p.u.bser, &err);
+        if (json == NULL) {
+            json = json_string(err.text);
+            flags |= JSON_ENCODE_ANY;
+        }
     }
     result = json_dumps(json, flags);
     if (p.type == PROTO_BSER) {

--- a/tests/bser2json.c
+++ b/tests/bser2json.c
@@ -10,10 +10,11 @@ int main(int argc, char* argv[]) {
     json_object_seed(1); /* make test results repeatable */
 #endif
     bser_t bser;
+    json_error_t err;
     bser_parse_from_file(stdin, &bser);
-    json_t* root = bser2json(&bser);
+    json_t* root = bser2json(&bser, &err);
     if (root == NULL) {
-        fprintf(stderr, "Could not convert BSER\n");
+        fprintf(stderr, "Could not convert BSER: %s\n", err.text);
     } else {
         json_dumpf(root, stdout, JSON_INDENT(4) | JSON_ENCODE_ANY);
         fprintf(stdout, "\n");

--- a/watchman.h
+++ b/watchman.h
@@ -217,6 +217,11 @@ struct watchman_version {
     int micro;
 };
 
+/**
+ * If set, errors and warnings are sent to this location
+ */
+void watchman_set_error_handle(FILE* fp);
+
 struct watchman_connection *
 watchman_connect(struct timeval timeout, struct watchman_error *error);
 int


### PR DESCRIPTION
Adds a callback to set a file descriptor to send output to.  Also capture and report BSER parsing errors.